### PR TITLE
Limit C9_USER to 16 char when used as MySQL user

### DIFF
--- a/ws-wordpress/Dockerfile
+++ b/ws-wordpress/Dockerfile
@@ -9,7 +9,7 @@ RUN cd /home/ubuntu/workspace && \
     mv wordpress/* . && \
     mv wp-config-sample.php wp-config.php && \
     sed -i -e "s/define('DB_NAME',.*/define('DB_NAME', 'c9');/" wp-config.php && \
-    sed -i -e "s/define('DB_USER',.*/define('DB_USER', getenv('C9_USER'));/" wp-config.php && \
+    sed -i -e "s/define('DB_USER',.*/define('DB_USER', substr(getenv('C9_USER'), 0, 16));/" wp-config.php && \
     sed -i -e "s/define('DB_PASSWORD',.*/define('DB_PASSWORD', '');/" wp-config.php && \
     sed -i -e "s/define('DB_HOST',.*/define('DB_HOST', getenv('IP'));/" wp-config.php && \
     sed -i -e '/define(.WP_DEBUG.*/ a\


### PR DESCRIPTION
MySQL has a default username char limit and when you have a long C9 account username (more than 16 chars) it will be **truncated** in the users table. This leds to a "Error establishing connection to database" because WP tries to login with the full username.
